### PR TITLE
fix: genesis- and wasm path in register script

### DIFF
--- a/scripts/registerParachain/index.js
+++ b/scripts/registerParachain/index.js
@@ -4,8 +4,8 @@ const { cryptoWaitReady } = require('@polkadot/util-crypto');
 const { setMinParaUpgradeDelay, registerParachain, forceLease, speedUpParaOnboarding } = require('./extrinsics');
 const { readFileFromPath } = require('./readFile');
 
-const wasmPath = path.join(__dirname, '/wasm', 'kilt.wasm');
-const genesisPath = path.join(__dirname, '/wasm', 'kilt-genesis.hex');
+const wasmPath = path.join('/wasm', 'kilt.wasm');
+const genesisPath = path.join('/wasm', 'kilt-genesis.hex');
 const relayProvider = process.env.RELAY_WS_ENDPOINT || 'ws://127.0.0.1:9944'
 const paraId = process.env.PARA_ID || 2000;
 const sudoHex = process.env.RELAY_SUDO;


### PR DESCRIPTION
Fixes path for WASM and genesis in registering script which was merged in #10. Sorry about that.

After merging this, please delete your existing image such that is rebuild

```
docker image remove node-register-parachain
```